### PR TITLE
fix: replace deprecated call to required with demandOption

### DIFF
--- a/get_requests.js
+++ b/get_requests.js
@@ -13,7 +13,7 @@ process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
 
 const { v3dir } = yargs
   .string("v3dir")
-  .required("v3dir")
+  .demandOption("v3dir")
   .describe(
     "v3dir",
     "Path to a checked out v3 SDK repo(https://github.com/aws/aws-sdk-js-v3.git). " +


### PR DESCRIPTION
`.required()` has been deprecated in yargs.

<details>
<summary>VSCode screenshot</summary>

![Screen Shot 2020-10-01 at 3 04 01 PM](https://user-images.githubusercontent.com/16024985/94868589-55baa480-03f8-11eb-8d4c-9d10c9f3a3af.png)

</details>

Verified that `Missing required argument` gets printed for `v3dir`:
```console
$ node get_requests.js
Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]
  --v3dir    Path to a checked out v3 SDK
             repo(https://github.com/aws/aws-sdk-js-v3.git). You need to run
             `yarn && yarn build:all` in v3 repo before running this
                                                             [string] [required]

Missing required argument: v3dir
```