### PR TITLE
fix: fake url-compatible string value

### DIFF
--- a/get_requests.js
+++ b/get_requests.js
@@ -88,7 +88,7 @@ const getFakeParams = (inputShape, shapes) => {
   if (inputShape.type === "list") {
     return [getFakeParams(inputShape.member, shapes)];
   }
-  return "stringValue";
+  return "stringvalue";
 };
 
 const parseCurlResponse = (stdout) => {


### PR DESCRIPTION
The faked string value `stringValue` contains upper-cased character that is not hostname-compatible. 

Fixes #5 